### PR TITLE
av: add support for oplus camera TAG_NAME

### DIFF
--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -129,6 +129,7 @@ cc_library {
         "camera_package_name_defaults",
         "camera_needs_client_info_lib_defaults",
         "camera_needs_client_info_lib_oplus_defaults",
+        "uses_oplus_camera_defaults",
     ],
     // Camera service source
 

--- a/services/camera/libcameraservice/device3/Camera3Device.cpp
+++ b/services/camera/libcameraservice/device3/Camera3Device.cpp
@@ -59,6 +59,10 @@
 #define ALOGVV(...) ((void)0)
 #endif
 
+#ifdef USES_OPLUS_CAMERA
+#define CAMERA_PACKAGE_NAME "com.oplus.packageName"
+#endif
+
 // Convenience macro for transient errors
 #define CLOGE(fmt, ...) ALOGE("Camera %s: %s: " fmt, mId.c_str(), __FUNCTION__, \
             ##__VA_ARGS__)


### PR DESCRIPTION
* The camera will be broken without this in some devices like Oplus sm8450